### PR TITLE
Ability to ignore missing validators, validate multiple at once

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,16 +74,18 @@ Anchor.prototype.to = function (ruleset, context, data) {
 	// Look for explicit rules
 	for (var rule in ruleset) {
 
+		var ruleData = typeof data === 'undefined' ? this.data : data;
+
 		if (rule === 'type') {
 
 			// Use deep match to descend into the collection and verify each item and/or key
 			// Stop at default maxDepth (50) to prevent infinite loops in self-associations
-			errors = errors.concat(Anchor.match.type.call(context, data || this.data, ruleset['type']));
+			errors = errors.concat(Anchor.match.type.call(context, ruleData, ruleset['type']));
 		}
 
 		// Validate a non-type rule
 		else {
-			errors = errors.concat(Anchor.match.rule.call(context, data || this.data, rule, ruleset[rule]));
+			errors = errors.concat(Anchor.match.rule.call(context, ruleData, rule, ruleset[rule]));
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -32,11 +32,22 @@ function Anchor (entity) {
 	}
 	else this.data = entity;
 
+	this.ignoreMissing = false;
+
 	return this;
 }
 
+/**
+ * Sets whether to ignore missing rules in Anchor, or not.
+ * 
+ * @param  {bool} ignore
+ * @return {Anchor}
+ */
+Anchor.prototype.ignore = function (ignore) {
+	this.ignoreMissing = typeof ignore === 'undefined' ? true : ignore;
 
-
+	return this;
+};
 
 
 /**
@@ -74,6 +85,13 @@ Anchor.prototype.to = function (ruleset, context, data) {
 		else {
 			errors = errors.concat(Anchor.match.rule.call(context, data || this.data, rule, ruleset[rule]));
 		}
+	}
+
+	if (this.ignoreMissing
+		&& errors.length === 1
+		&& errors[0].message.match(/^Unknown rule/i)) {
+
+		return false;
 	}
 
 	// If errors exist, return the list of them

--- a/index.js
+++ b/index.js
@@ -87,11 +87,12 @@ Anchor.prototype.to = function (ruleset, context, data) {
 		}
 	}
 
-	if (this.ignoreMissing
-		&& errors.length === 1
-		&& errors[0].message.match(/^Unknown rule/i)) {
+	for (var i = 0; i < errors.length; i++) {
 
-		return false;
+		if (this.ignoreMissing && errors[i].message.match(/^Unknown rule/i)) {
+			errors.splice(i--, 1);
+		}
+
 	}
 
 	// If errors exist, return the list of them

--- a/lib/match/matchRule.js
+++ b/lib/match/matchRule.js
@@ -15,8 +15,7 @@ var rules = require('./rules');
 
 module.exports = function matchRule (data, ruleName, args) {
   var self = this,
-    errors = [],
-    originalArgs = args;
+    errors = [];
 
   // if args is an array we need to make it a nested array
   if (Array.isArray(args)) {
@@ -27,6 +26,8 @@ module.exports = function matchRule (data, ruleName, args) {
   if (!_.isArray(args)) {
     args = [args];
   }
+  
+  var originalArgs = args;
 
   // push data on to front
   args.unshift(data);

--- a/lib/match/matchRule.js
+++ b/lib/match/matchRule.js
@@ -26,8 +26,8 @@ module.exports = function matchRule (data, ruleName, args) {
   if (!_.isArray(args)) {
     args = [args];
   }
-  
-  var originalArgs = args;
+
+  var originalArgs = _.clone(args);
 
   // push data on to front
   args.unshift(data);

--- a/lib/match/matchRule.js
+++ b/lib/match/matchRule.js
@@ -47,6 +47,7 @@ module.exports = function matchRule (data, ruleName, args) {
     return [{
       rule: ruleName,
       data: data,
+      args: args,
       message: util.format('"%s" validation rule failed for input: %s', ruleName, util.inspect(data))
     }];
   }

--- a/lib/match/matchRule.js
+++ b/lib/match/matchRule.js
@@ -15,7 +15,8 @@ var rules = require('./rules');
 
 module.exports = function matchRule (data, ruleName, args) {
   var self = this,
-    errors = [];
+    errors = [],
+    originalArgs = args;
 
   // if args is an array we need to make it a nested array
   if (Array.isArray(args)) {
@@ -47,7 +48,7 @@ module.exports = function matchRule (data, ruleName, args) {
     return [{
       rule: ruleName,
       data: data,
-      args: args,
+      args: originalArgs,
       message: util.format('"%s" validation rule failed for input: %s', ruleName, util.inspect(data))
     }];
   }

--- a/lib/match/matchRule.js
+++ b/lib/match/matchRule.js
@@ -34,7 +34,7 @@ module.exports = function matchRule (data, ruleName, args) {
   var outcome;
   var rule = rules[ruleName];
   if (!rule) {
-    throw new Error('Unknown rule: ' + ruleName);
+    return [Error('Unknown rule: ' + ruleName)];
   }
   try {
     outcome = rule.apply(self, args);

--- a/test/anchorToss.test.js
+++ b/test/anchorToss.test.js
@@ -1,0 +1,40 @@
+var _ = require('lodash');
+var anchor = require('../index.js');
+var testMultiple = require('./util/testMultiple.js');
+
+describe('anchor toss', function() {
+
+    it(' should properly support multiple validation rules', function() {
+        testMultiple({
+            name: {
+                type: 'string',
+                alpha: true
+            },
+            avatar: {
+                type: 'string'
+            }
+        }, {
+            name: 'Connor',
+            avatar: 'http://example.com/connor.png'
+        }, {
+            name: 'N0t ALPH4',
+            avatar: 'http://example.com/foobar.png'
+        });
+    });
+
+    it(' works well with "required"', function() {
+        testMultiple({
+            name: {
+                type: 'string',
+                required: true
+            },
+            avatar: {
+                type: 'string'
+            }
+        }, {
+            name: 'Connor'
+        }, {
+            
+        });
+    });
+});

--- a/test/ignoreMissing.test.js
+++ b/test/ignoreMissing.test.js
@@ -1,0 +1,20 @@
+var _ = require('lodash');
+var anchor = require('../index.js');
+var assert = require('assert');
+
+
+describe('handles missing rules', function() {
+
+  it(' should throw an error by default', function() {
+
+    assert(anchor('foo').to({type: 'string', somesillyrule: true}) !== false);
+
+  });
+
+  it(' should be ok ignoring missing rules', function() {
+
+    assert(anchor('foo').ignore().to({type: 'string', somesillyrule: true}) === false);
+
+  });
+
+});

--- a/test/util/testMultiple.js
+++ b/test/util/testMultiple.js
@@ -1,0 +1,32 @@
+var _ = require('lodash');
+var anchor = require('../../index.js');
+var async = require('async');
+
+// Test a rule given a deliberate example and nonexample
+// Test WITH and WITHOUT callback
+module.exports = function testRules (rules, example, nonexample) {
+
+    // Throw an error if there's any trouble
+    // (not a good production usage pattern-- just here for testing)
+    var exampleOutcome, nonexampleOutcome;
+
+    // Should be falsy
+    exampleOutcome = anchor(example).toss(rules);
+
+    // Should be an array
+    nonexampleOutcome = anchor(nonexample).toss(rules);
+
+    if (exampleOutcome !== false) {
+        return gotErrors('Valid input marked with error!', exampleOutcome, example);
+    }
+    if (nonexampleOutcome === false) {
+        return gotErrors('Invalid input (' + nonexample + ') allowed through.',
+            rules, nonexample);
+    }
+
+    function gotErrors (errMsg, err, data) {
+        console.error(err);
+        console.error(data);
+        throw new Error(errMsg);
+    }
+};


### PR DESCRIPTION
We're doing some front-end validation using the same attributes (with Anchor) that we do with waterline on the backend. I made some changes so this can be possible:
- validating multiple rules at once with Anchor.toss
- ability to ignore missing validations, so that we can just ignore things that waterline adds, like `unique`.

The only potentially kind of breaking change this uses is that missing validator errors are returned instead of thrown.  They are now handled in the same way that missing types are handled.

Unit tests pass.
