### PR TITLE
Add Custom Messages for Sails

### DIFF
--- a/lib/match/matchRule.js
+++ b/lib/match/matchRule.js
@@ -17,6 +17,12 @@ module.exports = function matchRule (data, ruleName, args) {
   var self = this,
     errors = [];
 
+  // supporting custom error messages
+  if (_.isObject(args)){
+    message = args.message.replace('{data}', data).replace('{rule}', args.value) || "No custom message provided.";
+    args = args.value || true;
+  }
+
   // if args is an array we need to make it a nested array
   if (Array.isArray(args)) {
     args = [args];
@@ -44,10 +50,11 @@ module.exports = function matchRule (data, ruleName, args) {
 
   // If outcome is false, an error occurred
   if (!outcome) {
+    var output = (message) ? message : util.format('"%s" validation rule failed for input: %s', ruleName, util.inspect(data));
     return [{
       rule: ruleName,
       data: data,
-      message: util.format('"%s" validation rule failed for input: %s', ruleName, util.inspect(data))
+      message: output
     }];
   }
   else {


### PR DESCRIPTION
Supports the following syntax for Waterline Models.

`{data}` is replaced with the offending value
`{rule}` is replaced with the value the validator is checking against

````
  attributes: {
    email: {
      type: 'string',
      email: { value: true, message: 'woah homie that\'s not an email {data}  {rule}' },
      minLength: { value: 10, message: 'not long enough, it should be at least {rule} big' },
      maxLength: { value: 12, message: 'woah there cowboy, that\'s {rule} too big' }
    }
  }
````