### PR TITLE
added isSubset rule

### DIFF
--- a/lib/match/rules.js
+++ b/lib/match/rules.js
@@ -122,6 +122,7 @@ module.exports = {
 	'maxLength'	: function (x, max) { return validator.isLength(x, 0, max); },
 
 	'regex' : function (x, regex) { return validator.matches(x, regex); },
-	'notRegex' : function (x, regex) { return !validator.matches(x, regex); }
+	'notRegex' : function (x, regex) { return !validator.matches(x, regex); },
+  'isSubset': function (x, array) { return _.isArray(x) && x.length === _.intersection(x, array).length;  }
 
 };


### PR DESCRIPTION
Created isSubset rule, which validates the following, given a value "A":
    - "A" is an Array: This is done using _.isArray
    - All values in "A" are in an array "B" of values which the rule expects to be passed as a parameter: This is done comparing the length of array "A" with the length of the _.intersection of "A" and "B". They should have the same length.
